### PR TITLE
[CernVM-FS] add 'Previous tutorials' subsection

### DIFF
--- a/isc24/CernVM-FS/main.tex
+++ b/isc24/CernVM-FS/main.tex
@@ -157,8 +157,10 @@
 \input{outline.tex}
 %\newpage
 
-\subsection*{Hands-on and presentation materials}
-\input{handson.tex}
+\input{previous_tutorials.tex}
+
+%\subsection*{Hands-on and presentation materials}
+%\input{handson.tex}
 
 \section{Logistics}
 

--- a/isc24/CernVM-FS/previous_tutorials.tex
+++ b/isc24/CernVM-FS/previous_tutorials.tex
@@ -1,0 +1,17 @@
+\subsection*{Previous tutorials}
+
+A free online introductory tutorial on CernVM-FS was organised as a part of the 6th EasyBuild User Meeting
+(Jan'21)\footnote{\href{https://easybuild.io/eum21/\#cvmfs-tutorial}{https://easybuild.io/eum21/\#cvmfs-tutorial}}.
+It consisted of 5 short sessions (1h each), one per day in the same week, and was attended by about 25 people.
+A quick evaluation survey afterwards showed that 75\% of attendees rated the tutorial as "excellent", while the remaining 25\%
+rated it as "good".
+
+\paragraph{}
+More recently (Dec'23), a ``\emph{Best Practices for CernVM-FS in HPC}'' 3-hour free online tutorial
+was organised in the context of the MultiXscale EuroHPC Centre-of-Excellence
+\footnote{\href{https://multixscale.github.io/cvmfs-tutorial-hpc-best-practices}{https://multixscale.github.io/cvmfs-tutorial-hpc-best-practices}}.
+It was a resounding success, with over 200 registrations, and 125 actual attendees during the online session.
+An evaluation survey that was completed by over 50 attendees showed that the tutorial was very well received:
+it got an average rating of 8.64 out of 10, with 88\% giving a score of 8 or higher, and over 90\% of survey
+participants stating that they would "definitely" recommend the tutorial to friends or colleagues (along with 8\%
+answering "maybe", and one person stating "I'm not sure").


### PR DESCRIPTION
 + remove dedicated 'hands-on + materials' section (covered elsewhere)